### PR TITLE
Fix installation issue on python3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -34,18 +34,6 @@ CLASSIFIERS = [
     'Programming Language :: Python',
 ]
 
-def read_file(name):
-    filepath = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        name
-    )
-    data = open(filepath)
-    try:
-        return data.read()
-    except IOError:
-        print "could not read %r" % name
-        data.close()
-
 def setup_package():
     # Some helper variables
     version = VERSION
@@ -62,7 +50,6 @@ def setup_package():
         license=LICENSE,
         keywords='philips hue light rgb xy',
         packages=setuptools.find_packages(),
-        long_description=read_file('README.md'),
         install_requires=install_reqs
     )
 


### PR DESCRIPTION
I'd like to use this library in google/aiyprojects-raspbian#33 however am having problems installing on python 3. The exception is below: 

This PR alters the mechanism to populate the long description avoiding the need to read a file. 

```
Collecting rgbxy
  Using cached rgbxy-0.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-x2igs7xs/rgbxy/setup.py", line 46
        print "could not read %r" % name
                                ^
    SyntaxError: Missing parentheses in call to 'print'
    
    ----------------------------------------
```